### PR TITLE
Switch NotNull reference over to Bean Validation API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,5 +211,10 @@
             <artifactId>uadetector-resources</artifactId>
             <version>2014.10</version>
         </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>2.0.1.Final</version>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -216,5 +216,10 @@
             <artifactId>validation-api</artifactId>
             <version>2.0.1.Final</version>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>5.2.4.Final</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/net/socialgamer/cah/serveralive/DiffieHellman.java
+++ b/src/main/java/net/socialgamer/cah/serveralive/DiffieHellman.java
@@ -1,6 +1,6 @@
 package net.socialgamer.cah.serveralive;
 
-import com.sun.istack.internal.NotNull;
+import javax.validation.constraints.NotNull;
 
 import javax.crypto.KeyAgreement;
 import javax.crypto.interfaces.DHPublicKey;


### PR DESCRIPTION
Fixes compilation issues using Maven and OpenJDK 8 on Centos 7 (and probably other distros, JDK versions etc.)